### PR TITLE
somewhat working

### DIFF
--- a/scripts/pathManager.js
+++ b/scripts/pathManager.js
@@ -284,7 +284,7 @@ export class Path
 
 					let stepCost = 1;
 
-					if (isDiagonal) {
+					if (isDiagonal && !canvas.grid.isHexagonal) {
 						newDiagCount = n.diagonalCount + 1;
 						stepCost = (newDiagCount % 2 === 1) ? 1 : 2;
 						debugLog(`FindThePath | Diagonal move #${newDiagCount}:`);

--- a/scripts/point.js
+++ b/scripts/point.js
@@ -113,6 +113,13 @@ function pf2eNeighborsFunc(point_) {
 		if (p && p.isValid) vector_.push(p);
 	};
 
+	if (canvas.grid.isHexagonal) {
+		for (let cp of canvas.grid.grid.getNeighbors(point_._x, point_._y)) {
+			pushIfDefined(n, cp[0] - point_._x, cp[1] - point_._y);
+		}
+		return n;
+	}
+
 	for (let dx of [-1, 0, 1]) {
 		for (let dy of [-1, 0, 1]) {
 			if (dx === 0 && dy === 0) continue;
@@ -124,19 +131,16 @@ function pf2eNeighborsFunc(point_) {
 }
 
 // Represents a token's position as a point in grid-space rather than pixel-space and provides some useful methods.
-export class Point
-{
-	constructor (data_)
-	{
-		if (data_.px)
-			this._x = data_.px / this.scale;
+		if (data_.px) {
+			this._x = canvas.grid.getGridPositionFromPixels(data_.px, data_.py)[1];
+		}
 		else if (data_.x)
 			this._x = data_.x;
 		else
 			this._x = 0;
 
 		if (data_.py)
-			this._y = data_.py / this.scale;
+			this._y = canvas.grid.getGridPositionFromPixels(data_.px, data_.py)[0];
 		else if (data_.y)
 			this._y = data_.y;
 		else
@@ -373,7 +377,7 @@ export class Point
 	get y () { return this._y; }
 	// x and y offset, in pixels
 	get px () { return this.x * this.scale; }
-	get py () { return this.y * this.scale; }
+	get py() { return canvas.grid.getPixelsFromGridPosition(this.x, this.y)[0]; }
 	// Returns the offset of the point's center, in pixels
 	get cx () { return this.x + 0.5; }
 	get cy () { return this.y + 0.5; }

--- a/scripts/point.js
+++ b/scripts/point.js
@@ -222,6 +222,7 @@ function pf2eNeighborsFunc(point_) {
 	static PF2E(p1_, p2_) {
 		const dx = Math.abs(p1_.x - p2_.x);
 		const dy = Math.abs(p1_.y - p2_.y);
+		if (canvas.grid.isHexagonal) { return dx + dy; }
 		
 		// Use as many diagonals as possible (minimum of dx and dy)
 		const diagonals = Math.min(dx, dy);

--- a/scripts/point.js
+++ b/scripts/point.js
@@ -114,8 +114,8 @@ function pf2eNeighborsFunc(point_) {
 	};
 
 	if (canvas.grid.isHexagonal) {
-		for (let cp of canvas.grid.grid.getNeighbors(point_._x, point_._y)) {
-			pushIfDefined(n, cp[0] - point_._x, cp[1] - point_._y);
+		for (let cp of canvas.grid.getAdjacentOffsets({"i": point_._y, "j" : point_._x})) {
+			pushIfDefined(n, cp["j"] - point_._x, cp["i"] - point_._y, );
 		}
 		return n;
 	}
@@ -136,15 +136,16 @@ export class Point
 	{
 		// Represents a token's position as a point in grid-space rather than pixel-space and provides some useful methods.
 		if (data_.px) {
-			this._x = canvas.grid.getGridPositionFromPixels(data_.px, data_.py)[1];
+			this._x = canvas.grid.getOffset({x: data_.px, y: data_.py})["j"];
 		}
 		else if (data_.x)
 			this._x = data_.x;
 		else
 			this._x = 0;
 
-		if (data_.py)
-			this._y = canvas.grid.getGridPositionFromPixels(data_.px, data_.py)[0];
+		if (data_.py){
+			this._y = canvas.grid.getOffset({x: data_.px, y: data_.py})["i"];
+		}
 		else if (data_.y)
 			this._y = data_.y;
 		else
@@ -381,14 +382,19 @@ export class Point
 	get x () { return this._x; }
 	get y () { return this._y; }
 	// x and y offset, in pixels
-	get px () { return this.x * this.scale; }
-	get py() { return canvas.grid.getPixelsFromGridPosition(this.x, this.y)[0]; }
+	get px() { 	return canvas.grid.getCenterPoint({"j": this.x, "i": this.y}).x; }
+	get py() { 
+		let out = canvas.grid.getCenterPoint({"j": this.x, "i": this.y}).y;
+		if (canvas.grid.isHexagonal) out += this.scale / ((1 / 3.0)*10.0);
+		return out;
+	}
 	// Returns the offset of the point's center, in pixels
 	get cx () { return this.x + 0.5; }
 	get cy () { return this.y + 0.5; }
 	// Returns the offset of the point's center, in pixels
-	get cpx () { return (this.x + 0.5) * this.scale; }
-	get cpy () { return (this.y + 0.5) * this.scale; }
+	get cpx () { //console.log("find_", canvas.grid.getCenterPoint({"j": this.x, "i": this.y}));
+		return canvas.grid.getCenterPoint({"j": this.x, "i": this.y}).x; }
+	get cpy () { return canvas.grid.getCenterPoint({"j": this.x, "i": this.y}).y; }
 
 	get scale () { return canvas.grid.size; }
 

--- a/scripts/point.js
+++ b/scripts/point.js
@@ -130,7 +130,11 @@ function pf2eNeighborsFunc(point_) {
 	return n;
 }
 
-// Represents a token's position as a point in grid-space rather than pixel-space and provides some useful methods.
+export class Point
+{
+	constructor (data_)
+	{
+		// Represents a token's position as a point in grid-space rather than pixel-space and provides some useful methods.
 		if (data_.px) {
 			this._x = canvas.grid.getGridPositionFromPixels(data_.px, data_.py)[1];
 		}


### PR DESCRIPTION
It doesn't work perfectly, but the general idea is there.
If you got an idea how to fix the small offset, I'd appreciate it.
Also it's only accurate on hexagonal rows, not columns. That's probably 'cause `get py() { return canvas.grid.getPixelsFromGridPosition(this.x, this.y)[0]; }` is correct on rows and `get px() { return canvas.grid.getPixelsFromGridPosition(this.x, this.y)[1]; }` is correct on cols.
My branch still works on square grids.


![image](https://github.com/user-attachments/assets/8b571bc5-3509-47cc-a1ab-1cc8a49b3556)
